### PR TITLE
bug fixes

### DIFF
--- a/app/src/main/java/com/obsez/android/lib/filechooser/demo/ChooseFileActivityFragment.java
+++ b/app/src/main/java/com/obsez/android/lib/filechooser/demo/ChooseFileActivityFragment.java
@@ -170,7 +170,7 @@ public class ChooseFileActivityFragment extends Fragment implements View.OnClick
                 assert ctx != null;
                 final ChooserDialog dialog = new ChooserDialog(ctx);
                 dialog.enableOptions(true)
-                    .withFilterRegex(false, true, ".*\\.txt")
+                    .withFilter(false, false)
                     .withStartFile(_path)
                     .withResources(R.string.title_choose_multiple, R.string.new_folder_ok,
                         R.string.dialog_cancel)

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -837,15 +837,50 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
             File f = Environment.getExternalStorageDirectory();
             //File newRoot = _currentDir.getParentFile();
             if (_currentDir.getAbsolutePath().equals(primaryRoot)) {
-                _entries.add(new File(".. SDCard Storage")); //⇠
+                _entries.add(new File(".. SDCard Storage"){
+                    @Override
+                    public boolean isDirectory(){
+                        return true;
+                    }
+                    @Override
+                    public boolean isHidden(){
+                        return false;
+                    }
+                    @Override
+                    public long lastModified(){
+                        return 0L;
+                    }
+                }); //⇠
                 up = true;
             } else {
-                _entries.add(new File(".. Primary Storage")); //⇽
+                _entries.add(new File(".. Primary Storage"){
+                    @Override
+                    public boolean isDirectory(){
+                        return true;
+                    }
+                    @Override
+                    public boolean isHidden(){
+                        return false;
+                    }
+                    @Override
+                    public long lastModified(){
+                        return 0L;
+                    }
+                }); //⇽
                 up = true;
             }
         }
         if (!up && _currentDir.getParentFile() != null && _currentDir.getParentFile().canRead()) {
-            _entries.add(new File(".."));
+            _entries.add(new File(".."){
+                @Override
+                public boolean isHidden(){
+                    return false;
+                }
+                @Override
+                public long lastModified(){
+                    return 0L;
+                }
+            });
         }
 
         if (files == null) return;
@@ -936,6 +971,19 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
                 _currentDir = f;
                 _chooseMode = _chooseMode == CHOOSE_MODE_DELETE ? CHOOSE_MODE_NORMAL : _chooseMode;
                 scrollToTop = true;
+            }
+        } else if (file.getName().contains(".. SDCard Storage")){
+            String removableRoot = FileUtil.getStoragePath(_context, true);
+            if(removableRoot != null && Environment.MEDIA_MOUNTED.equals(
+                Environment.getExternalStorageState())){
+                _currentDir = new File(removableRoot);
+                _chooseMode = _chooseMode == CHOOSE_MODE_DELETE ? CHOOSE_MODE_NORMAL : _chooseMode;
+            }
+        } else if (file.getName().contains(".. Primary Storage")){
+            String primaryRoot = FileUtil.getStoragePath(_context, false);
+            if(primaryRoot != null){
+                _currentDir = new File(primaryRoot);
+                _chooseMode = _chooseMode == CHOOSE_MODE_DELETE ? CHOOSE_MODE_NORMAL : _chooseMode;
             }
         } else {
             switch (_chooseMode) {

--- a/library/src/main/java/com/obsez/android/lib/filechooser/tool/DirAdapter.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/tool/DirAdapter.java
@@ -62,6 +62,7 @@ public class DirAdapter extends ArrayAdapter<File> {
     }
 
     // This function is called to show each view item
+    @SuppressWarnings("ConstantConditions")
     @NonNull
     @Override
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
@@ -78,7 +79,12 @@ public class DirAdapter extends ArrayAdapter<File> {
         if (file == null) return rl;
         tvName.setText(file.getName());
         if (file.isDirectory()) {
-            final Drawable folderIcon = _defaultFolderIcon;
+            final Drawable folderIcon = _defaultFolderIcon.getConstantState().newDrawable();
+            if(file.isHidden()){
+                final PorterDuffColorFilter filter = new PorterDuffColorFilter(0x60ffffff,
+                    PorterDuff.Mode.SRC_ATOP);
+                folderIcon.mutate().setColorFilter(filter);
+            }
             tvName.setCompoundDrawablesWithIntrinsicBounds(folderIcon, null, null, null);
             tvSize.setText("");
             if (!file.getName().trim().equals("..")) {
@@ -97,15 +103,21 @@ public class DirAdapter extends ArrayAdapter<File> {
             if (d == null) {
                 d = _defaultFileIcon;
             }
-            tvName.setCompoundDrawablesWithIntrinsicBounds(d, null, null, null);
+            final Drawable fileIcon = d.getConstantState().newDrawable();
+            if(file.isHidden()){
+                final PorterDuffColorFilter filter = new PorterDuffColorFilter(0x80ffffff,
+                    PorterDuff.Mode.SRC_ATOP);
+                fileIcon.mutate().setColorFilter(filter);
+            }
+            tvName.setCompoundDrawablesWithIntrinsicBounds(fileIcon, null, null, null);
             tvSize.setText(FileUtil.getReadableFileSize(file.length()));
             tvDate.setText(_formatter.format(new Date(file.lastModified())));
-
         }
 
         View root = rl.findViewById(R.id.root);
         if (_selected.get(file.hashCode(), null) == null) root.getBackground().clearColorFilter();
-        else root.getBackground().setColorFilter(_colorFilter);
+          else root.getBackground().setColorFilter(_colorFilter);
+
         return rl;
     }
 
@@ -136,7 +148,6 @@ public class DirAdapter extends ArrayAdapter<File> {
     public void setEntries(List<File> entries) {
         super.clear();
         super.addAll(entries);
-        notifyDataSetChanged();
     }
 
     @Override

--- a/library/src/main/java/com/obsez/android/lib/filechooser/tool/DirAdapter.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/tool/DirAdapter.java
@@ -104,7 +104,7 @@ public class DirAdapter extends ArrayAdapter<File> {
                 d = _defaultFileIcon;
             }
             final Drawable fileIcon = d.getConstantState().newDrawable();
-            if(file.isHidden()){
+            if(file.isHidden() && !file.getName().trim().equals("..")){
                 final PorterDuffColorFilter filter = new PorterDuffColorFilter(0x80ffffff,
                     PorterDuff.Mode.SRC_ATOP);
                 fileIcon.mutate().setColorFilter(filter);

--- a/library/src/main/java/com/obsez/android/lib/filechooser/tool/DirAdapter.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/tool/DirAdapter.java
@@ -78,16 +78,11 @@ public class DirAdapter extends ArrayAdapter<File> {
         File file = super.getItem(position);
         if (file == null) return rl;
         tvName.setText(file.getName());
+        Drawable icon;
         if (file.isDirectory()) {
-            final Drawable folderIcon = _defaultFolderIcon.getConstantState().newDrawable();
-            if(file.isHidden()){
-                final PorterDuffColorFilter filter = new PorterDuffColorFilter(0x60ffffff,
-                    PorterDuff.Mode.SRC_ATOP);
-                folderIcon.mutate().setColorFilter(filter);
-            }
-            tvName.setCompoundDrawablesWithIntrinsicBounds(folderIcon, null, null, null);
+            icon = _defaultFolderIcon.getConstantState().newDrawable();
             tvSize.setText("");
-            if (!file.getName().trim().equals("..")) {
+            if (file.lastModified() != 0L) {
                 tvDate.setText(_formatter.format(new Date(file.lastModified())));
             } else {
                 tvDate.setVisibility(View.GONE);
@@ -103,16 +98,16 @@ public class DirAdapter extends ArrayAdapter<File> {
             if (d == null) {
                 d = _defaultFileIcon;
             }
-            final Drawable fileIcon = d.getConstantState().newDrawable();
-            if(file.isHidden() && !file.getName().trim().equals("..")){
-                final PorterDuffColorFilter filter = new PorterDuffColorFilter(0x80ffffff,
-                    PorterDuff.Mode.SRC_ATOP);
-                fileIcon.mutate().setColorFilter(filter);
-            }
-            tvName.setCompoundDrawablesWithIntrinsicBounds(fileIcon, null, null, null);
+            icon = d.getConstantState().newDrawable();
             tvSize.setText(FileUtil.getReadableFileSize(file.length()));
             tvDate.setText(_formatter.format(new Date(file.lastModified())));
         }
+        if(file.isHidden()){
+            final PorterDuffColorFilter filter = new PorterDuffColorFilter(0x80ffffff,
+                PorterDuff.Mode.SRC_ATOP);
+            icon.mutate().setColorFilter(filter);
+        }
+        tvName.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
 
         View root = rl.findViewById(R.id.root);
         if (_selected.get(file.hashCode(), null) == null) root.getBackground().clearColorFilter();


### PR DESCRIPTION
* fixed NewFileFilter
* fixed FileFilter and hidden files
* fixed options buttons text colors
* now scrolls to the top when directory is changed
* now hidden file icons are a little ~~transparent~~ whiter
* also gave the new `.. SDCard Storage` and `.. Primary Storage` the look that `..` had (no size, no last modified date and directory icon)

PS. If withFileFilter was used with no suffixes, _fileFilter would be set to a ExtFileFilter with empty suffixes, thus even if dirOnly was false no files would be shown.
In android hidden files are those that start with '.' (dot), thus I removed the if(!f.getName().startsWith(".")) statement from listDirs(). (therefore, they will show if the filter allows it)
And finally, the default FileFilters didn't check whether hidden files were allowed or not.