### PR TITLE
(#45) display file path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.21'
     repositories {
         jcenter()
         google()
@@ -16,7 +16,7 @@ buildscript {
 
         classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.0')
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -1184,7 +1184,7 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
         if (_alertDialog != null && _displayPath) {
             if (up) {
                 displayPath(null);
-            } else if (_displayPath) {
+            } else {
                 displayPath(_currentDir.getPath());
             }
         }

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -1184,7 +1184,7 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
         if (_alertDialog != null && _displayPath) {
             if (up) {
                 displayPath(null);
-            } else if (_followDir) {
+            } else if (_displayPath) {
                 displayPath(_currentDir.getPath());
             }
         }


### PR DESCRIPTION
an alternative solution to showing current directory in the title. a TextView at the top of the list with the current path. If whole path doesn't fit, then it gets trimmed from the left. This will not remove _folowDir, but rather give an alternative, as it doesn't require the title to be enabled. Oh, and I also updated android-maven-gradle-plugin: 2.0 -> 2.1 and kotlin-gradle-plugin: 1.3.11 -> 1.3.21.

heres a demo:
![demo](https://user-images.githubusercontent.com/27736965/53578348-f1d35880-3b90-11e9-9ef4-7ed0276ca603.gif)