### PR TITLE
Support (Alert)Dialog appcompat

### DIFF
--- a/app/src/main/java/com/obsez/android/lib/filechooser/demo/ChooseFileActivityFragment.java
+++ b/app/src/main/java/com/obsez/android/lib/filechooser/demo/ChooseFileActivityFragment.java
@@ -1,7 +1,6 @@
 package com.obsez.android.lib.filechooser.demo;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
@@ -20,6 +19,7 @@ import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.support.v7.app.AlertDialog;
 
 import com.obsez.android.lib.filechooser.ChooserDialog;
 import com.obsez.android.lib.filechooser.demo.tool.ImageUtil;

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="FileChooserDialogStyle_Dark" parent="@android:style/Theme.Material.Dialog.Alert">
+    <!--<style name="FileChooserDialogStyle_Dark" parent="@android:style/Theme.Material.Dialog.Alert">
         <item name="android:buttonStyle">@android:style/Widget.Holo.Light.Button</item>
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="colorAccent">@android:style/TextAppearance.Holo.DialogWindowTitle</item>
@@ -17,6 +17,6 @@
 
     <style name="FileChooserButtonStyle_Dark" parent="FileChooserButtonStyle">
         <item name="android:textColor">@android:color/holo_blue_light</item>
-    </style>
+    </style>-->
 
 </resources>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -8,15 +8,6 @@
         <item name="android:windowTitleStyle">@style/FileChooserTitleStyle_Dark</item>
         <item name="android:buttonBarButtonStyle">@style/FileChooserButtonStyle_Dark</item>
         <item name="android:backgroundDimAmount">0.8</item>
-    </style>
-
-    <style name="FileChooserTitleStyle_Dark" parent="FileChooserTitleStyle">
-        <item name="android:textAppearance">@android:style/TextAppearance.Holo.DialogWindowTitle</item>
-        <item name="android:textColor">@android:color/holo_blue_light</item>
-    </style>
-
-    <style name="FileChooserButtonStyle_Dark" parent="FileChooserButtonStyle">
-        <item name="android:textColor">@android:color/holo_blue_light</item>
     </style>-->
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,11 +21,12 @@
         <item name="colorAccent">@android:color/holo_blue_light</item>
         <item name="android:windowTitleStyle">@style/FileChooserTitleStyle_Dark</item>
         <item name="android:buttonBarButtonStyle">@style/FileChooserButtonStyle_Dark</item>
+        <item name="buttonBarButtonStyle">@style/FileChooserButtonStyle_Dark</item>
         <item name="android:backgroundDimAmount">0.8</item>
     </style>
 
     <style name="FileChooserTitleStyle_Dark" parent="FileChooserTitleStyle">
-        <item name="android:textAppearance">@android:style/TextAppearance.Holo.DialogWindowTitle</item>
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title.Inverse</item>
         <item name="android:textColor">@android:color/holo_blue_light</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
     </style>
 
     <style name="FileChooserDialogStyle_Dark">
-        <item name="android:windowBackground">@android:color/transparent</item>
+        <!--<item name="android:windowBackground">@android:color/transparent</item>-->
         <item name="android:textColorPrimary">@android:color/holo_blue_light</item>
         <item name="colorAccent">@android:color/holo_blue_light</item>
         <item name="android:windowTitleStyle">@style/FileChooserTitleStyle_Dark</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,7 +15,7 @@
         <item name="fileChooserNewFolderStyle">@style/FileChooserNewFolderStyle_Dark</item>
     </style>
 
-    <style name="FileChooserDialogStyle_Dark">
+    <style name="FileChooserDialogStyle_Dark" parent="Theme.AppCompat.Dialog.Alert">
         <!--<item name="android:windowBackground">@android:color/transparent</item>-->
         <item name="android:textColorPrimary">@android:color/holo_blue_light</item>
         <item name="colorAccent">@android:color/holo_blue_light</item>
@@ -26,6 +26,7 @@
 
     <style name="FileChooserTitleStyle_Dark" parent="FileChooserTitleStyle">
         <item name="android:textAppearance">@android:style/TextAppearance.Holo.DialogWindowTitle</item>
+        <item name="android:textColor">@android:color/holo_blue_light</item>
     </style>
 
     <style name="FileChooserButtonStyle_Dark" parent="FileChooserButtonStyle">

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -643,7 +643,7 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
             // In case the root id was changed or not found.
             if (root == null) {
                 rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", "android");
-                ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+                root = ((AlertDialog) dialog).findViewById(rootId);
                 if (root == null) return;
             }
 

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -638,12 +638,12 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
 
     private void displayPath(String path) {
         if (_pathView == null) {
-            int rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", _c.get()._context.getPackageName());
-            ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+            int rootId = _context.getResources().getIdentifier("contentPanel", "id", _context.getPackageName());
+            ViewGroup root = ((AlertDialog) _alertDialog).findViewById(rootId);
             // In case the root id was changed or not found.
             if (root == null) {
-                rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", "android");
-                root = ((AlertDialog) dialog).findViewById(rootId);
+                rootId = _context.getResources().getIdentifier("contentPanel", "id", "android");
+                root = ((AlertDialog) _alertDialog).findViewById(rootId);
                 if (root == null) return;
             }
 

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -638,10 +638,14 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
 
     private void displayPath(String path) {
         if (_pathView == null) {
-            final int rootId = _context.getResources().getIdentifier("contentPanel", "id", "android");
-            final ViewGroup root = ((AlertDialog) _alertDialog).findViewById(rootId);
-            // In case the id was changed or not found.
-            if (root == null) return;
+            int rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", _c.get()._context.getPackageName());
+            ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+            // In case the root id was changed or not found.
+            if (root == null) {
+                rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", "android");
+                ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+                if (root == null) return;
+            }
 
             ViewGroup.MarginLayoutParams params;
             if (root instanceof LinearLayout) {

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -7,7 +7,6 @@ import static com.obsez.android.lib.filechooser.internals.FileUtil.NewFolderFilt
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -23,6 +22,7 @@ import android.support.annotation.StyleRes;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.view.ContextThemeWrapper;
+import android.support.v7.app.AlertDialog;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;

--- a/library/src/main/java/com/obsez/android/lib/filechooser/defBackPressed.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/defBackPressed.java
@@ -1,7 +1,7 @@
 package com.obsez.android.lib.filechooser;
 
-import android.app.AlertDialog;
-import android.app.Dialog;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatDialog;
 
 import java.lang.ref.WeakReference;
 
@@ -33,6 +33,6 @@ class defBackPressed implements ChooserDialog.OnBackPressedListener {
     ChooserDialog.OnBackPressedListener _onBackPressed;
     ChooserDialog.OnBackPressedListener _onLastBackPressed;
 
-    private static final ChooserDialog.OnBackPressedListener _defaultLastBack = Dialog::cancel;
-    private static final ChooserDialog.OnBackPressedListener _defaultBack = Dialog::cancel;
+    private static final ChooserDialog.OnBackPressedListener _defaultLastBack = AppCompatDialog::cancel;
+    private static final ChooserDialog.OnBackPressedListener _defaultBack = AppCompatDialog::cancel;
 }

--- a/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
@@ -192,13 +192,14 @@ class onShowListener implements DialogInterface.OnShowListener {
                         // region Draw options view. (this only happens the first time one clicks on options)
                         // Root view (FrameLayout) of the ListView in the AlertDialog.
                         int rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", _c.get()._context.getPackageName());
-                        ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+                        ViewGroup tmpRoot = ((AlertDialog) dialog).findViewById(rootId);
                         // In case the root id was changed or not found.
-                        if (root == null) {
+                        if (tmpRoot == null) {
                             rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", "android");
-                            root = ((AlertDialog) dialog).findViewById(rootId);
-                            if (root == null) return;
+                            tmpRoot = ((AlertDialog) dialog).findViewById(rootId);
+                            if (tmpRoot == null) return;
                         }
+                        final ViewGroup root = tmpRoot;
 
                         // Create options view.
                         final FrameLayout options = new FrameLayout(_c.get()._context);

--- a/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
@@ -191,11 +191,14 @@ class onShowListener implements DialogInterface.OnShowListener {
                     if (_c.get()._options == null) {
                         // region Draw options view. (this only happens the first time one clicks on options)
                         // Root view (FrameLayout) of the ListView in the AlertDialog.
-                        final int rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id",
-                            "android");
-                        final ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+                        int rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", _c.get()._context.getPackageName());
+                        ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
                         // In case the root id was changed or not found.
-                        if (root == null) return;
+                        if (root == null) {
+                            rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", "android");
+                            ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+                            if (root == null) return;
+                        }
 
                         // Create options view.
                         final FrameLayout options = new FrameLayout(_c.get()._context);

--- a/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
@@ -17,7 +17,6 @@ import static com.obsez.android.lib.filechooser.ChooserDialog.CHOOSE_MODE_NORMAL
 import static com.obsez.android.lib.filechooser.ChooserDialog.CHOOSE_MODE_SELECT_MULTIPLE;
 import static com.obsez.android.lib.filechooser.internals.UiUtil.getListYScroll;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.TypedArray;
@@ -28,6 +27,7 @@ import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.view.ContextThemeWrapper;
+import android.support.v7.app.AlertDialog;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.view.View;

--- a/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/onShowListener.java
@@ -196,7 +196,7 @@ class onShowListener implements DialogInterface.OnShowListener {
                         // In case the root id was changed or not found.
                         if (root == null) {
                             rootId = _c.get()._context.getResources().getIdentifier("contentPanel", "id", "android");
-                            ViewGroup root = ((AlertDialog) dialog).findViewById(rootId);
+                            root = ((AlertDialog) dialog).findViewById(rootId);
                             if (root == null) return;
                         }
 

--- a/library/src/main/res/values-v21/styles.xml
+++ b/library/src/main/res/values-v21/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" tools:ignore="ResourceName,PrivateResource">
 
-    <public name="FileChooserDialogStyle" type="style" />
+    <!--<public name="FileChooserDialogStyle" type="style" />
     <style name="FileChooserDialogStyle" parent="@android:style/Theme.Material.Light.Dialog.Alert">
         <item name="android:windowTitleStyle">@style/FileChooserTitleStyle</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -13,6 +13,6 @@
         <item name="android:windowIsFloating">true</item>
         <item name="android:buttonBarStyle">@android:style/Holo.Light.ButtonBar.AlertDialog</item>
         <item name="android:buttonBarButtonStyle">@style/FileChooserButtonStyle</item>
-    </style>
+    </style>-->
 
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -44,7 +44,7 @@
     <!-- Dialog -->
     <public name="FileChooserDialogStyle" type="style" />
     <style name="FileChooserDialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="android:windowBackground">@android:color/transparent</item>
+        <!--<item name="android:windowBackground">@android:color/transparent</item>-->
         <item name="android:windowTitleStyle">@style/FileChooserTitleStyle</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowMinWidthMajor">@android:dimen/dialog_min_width_major</item>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -53,20 +53,23 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:windowIsFloating">true</item>
-        <item name="android:buttonBarStyle">@android:style/Holo.Light.ButtonBar.AlertDialog</item>
+        <item name="android:buttonBarStyle">@style/Widget.AppCompat.ButtonBar.AlertDialog</item>
+        <item name="buttonBarStyle">@style/Widget.AppCompat.ButtonBar.AlertDialog</item>
         <item name="android:buttonBarButtonStyle">@style/FileChooserButtonStyle</item>
+        <item name="buttonBarButtonStyle">@style/FileChooserButtonStyle</item>
     </style>
 
     <public name="FileChooserTitleStyle" type="style" />
     <style name="FileChooserTitleStyle">
         <item name="android:maxLines">1</item>
         <item name="android:scrollHorizontally">true</item>
-        <item name="android:textAppearance">@android:style/TextAppearance.DialogWindowTitle</item>
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
         <item name="android:textColor">#f000</item>
     </style>
 
     <public name="FileChooserButtonStyle" type="style" />
-    <style name="FileChooserButtonStyle" parent="@android:style/Holo.Light.ButtonBar.AlertDialog">
+    <style name="FileChooserButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textAppearanceButton">@style/TextAppearance.AppCompat.Button</item>
         <item name="android:textColor">@color/material_deep_teal_500</item>
     </style>
 


### PR DESCRIPTION
*Changes*

Replaced _android.app.(Alert)Dialog_ with appcompat version for backwards compatible, theme and style support.

This can help to fix issues #61 and #62

```xml
    <style name="FullscreenDialog" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
        <item name="android:layout_width">match_parent</item>
        <item name="android:layout_height">match_parent</item>
        <item name="android:windowBackground">@color/white</item>
        <item name="android:windowNoTitle">true</item>
        <item name="android:windowIsFloating">false</item>
    </style>
```

```java
new AlertDialog.Builder(context, isTablet ? R.style.ThemeOverlay_MaterialComponents_Dialog_Alert : R.style.FullscreenDialog)
```